### PR TITLE
Fix AnalysisTask's IllegalArgumentException (#1)

### DIFF
--- a/macro/src/main/java/com/github/johypark97/varchivemacro/macro/fxgui/model/service/task/AnalysisTask.java
+++ b/macro/src/main/java/com/github/johypark97/varchivemacro/macro/fxgui/model/service/task/AnalysisTask.java
@@ -69,7 +69,7 @@ public class AnalysisTask extends InterruptibleTask<Void> {
         this.onDataReady = onDataReady;
 
         analyzerThreadCount = threadCount;
-        imagePreloaderThreadCount = (int) (Math.log(threadCount) / Math.log(2));
+        imagePreloaderThreadCount = (int) (Math.log(threadCount + 1) / Math.log(2));
         imagePreloadingLimit = threadCount * 3 / 2;
 
         cacheManager = new CacheManager(cacheDirectoryPath);


### PR DESCRIPTION
분석 작업을 스레드 수 1로 하여 실행하였을 때 IllegalArgumentException 예외가 던져지는 문제를 수정함.